### PR TITLE
Simplified search

### DIFF
--- a/tests/unit/cli/search/test_reindex.py
+++ b/tests/unit/cli/search/test_reindex.py
@@ -34,7 +34,6 @@ def test_project_docs(db_session):
             "_type": "project",
             "_source": {
                 "name": p.name,
-                "name.normalized": p.normalized_name,
                 "version": [r.version for r in prs],
             },
         }

--- a/tests/unit/packaging/test_search.py
+++ b/tests/unit/packaging/test_search.py
@@ -42,7 +42,6 @@ def test_build_search():
 
     assert obj.meta.id == "foobar"
     assert obj["name"] == "Foobar"
-    assert obj["name.normalized"] == "foobar"
     assert obj["version"] == ["1.0", "2.0", "3.0", "4.0"]
     assert obj["summary"] == "This is my summary"
     assert obj["description"] == "This is my description"

--- a/warehouse/cli/search/reindex.py
+++ b/warehouse/cli/search/reindex.py
@@ -15,7 +15,7 @@ import os
 
 import click
 
-from elasticsearch.helpers import streaming_bulk
+from elasticsearch.helpers import bulk
 from sqlalchemy.orm import lazyload, joinedload
 
 from warehouse.cli.search import search
@@ -76,8 +76,7 @@ def reindex(config, **kwargs):
         )
         db.execute("SET statement_timeout = '600s'")
 
-        for _ in streaming_bulk(client, _project_docs(db)):
-            pass
+        bulk(client, _project_docs(db))
     except:
         new_index.delete()
         raise


### PR DESCRIPTION
- normalized_name should not be needed since the es analyzers should
  take of the normalizations
- match query automatically adapts to the field and does the right thing
- iterating over results yields nice results, no need for _source etc
- disabled the _all field to save some space in the index. This requires
  that all searches must explicitly specify fields (which all current
  searched do)
- empty fields should present as empty string, no need for
  .get('summary')
